### PR TITLE
downgrade msal.js

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,11 +7,11 @@
     <link rel="SHORTCUT ICON" href="./favicon.svg" type="image/x-icon">
     
     <!-- msal.min.js can be used in the place of msal.js; included msal.js to make debug easy -->
-    <script src="https://alcdn.msauth.net/browser/2.3.1/js/msal-browser.js" integrity="sha384-khe4Bq8VcpAsK8zAycaYefEMHsLny9P/kgPF9Jy1afhFNZ4EODmrdq//+LFp1mWV" crossorigin="anonymous"></script>
+    <script src="https://alcdn.msauth.net/browser/2.3.0/js/msal-browser.js" integrity="sha384-ILJg8BOvXQwFGYEbkLVLYTYoNpTT7tP905UubLu2AqwksVdddAu5z9k3e6gMhqc5" crossorigin="anonymous"></script>
 
     <!-- msal.js with a fallback to backup CDN -->
     <script type="text/javascript">
-      if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.3.1/js/msal-browser.js' type='text/javascript' crossorigin='anonymous' %3E%3C/script%3E"));
+      if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.3.0/js/msal-browser.js' type='text/javascript' crossorigin='anonymous' %3E%3C/script%3E"));
     </script>
 
     <!-- adding Bootstrap 4 for UI components  -->


### PR DESCRIPTION
This PR downgrades msal-browser from 2.3.1 to 2.3.0 due to a [known issue](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2476).