### PR TITLE
Update authConfig.js

### DIFF
--- a/app/authConfig.js
+++ b/app/authConfig.js
@@ -7,7 +7,7 @@ const msalConfig = {
     auth: {
         // 'Application (client) ID' of app registration in Azure portal - this value is a GUID
         clientId: "Enter_the_Application_Id_Here",
-        // Full directory URL, in the form of https://login.microsoftonline.com/<tenant>
+        // Full directory URL, in the form of https://login.microsoftonline.com/<tenant-id>
         authority: "Enter_the_Cloud_Instance_Id_HereEnter_the_Tenant_Info_Here",
         // Full redirect URL, in form of http://localhost:3000
         redirectUri: "Enter_the_Redirect_Uri_Here",


### PR DESCRIPTION
update incorrect URL example.  clicking the sign in button fails if you enter your tenant *name* in the authority value, it requires tenant *id*